### PR TITLE
Fix "Error: Cannot find module 'jshint/src/cli/cli'"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "grunt": "0.4.1",
     "grunt-cli": "0.1.9",
-    "grunt-contrib-jshint": "0.6.0"
+    "grunt-contrib-jshint": "0.6.4"
   },
   "scripts": {
     "test": "grunt --verbose"


### PR DESCRIPTION
Updating grunt-contrib-jshint to 0.6.4
